### PR TITLE
Testnet Release Changes

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,18 +1,12 @@
 FROM node:10
-
 ENV APP_HOME /app
-
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
-
 COPY package.json $APP_HOME
 COPY yarn.lock $APP_HOME
-
-RUN yarn install
-
+COPY webpack.config.js $APP_HOME
 COPY . $APP_HOME
-
+RUN yarn install && yarn build:prod
 ENV HOST=0.0.0.0 PORT=4200
-
 EXPOSE ${PORT}
 CMD [ "yarn", "start" ]

--- a/backend/package.json
+++ b/backend/package.json
@@ -114,7 +114,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.8.4",
-    "@pokt-network/pocket-js": "^0.4.0-rc",
+    "@pokt-network/pocket-js": "0.5.0-rc",
     "@sendgrid/mail": "^7.1.0",
     "axios": "^0.19.2",
     "bcrypt": "^4.0.1",

--- a/backend/src/_configuration.js
+++ b/backend/src/_configuration.js
@@ -8,144 +8,156 @@ import dotenv from "dotenv";
 dotenv.config();
 
 export const Configurations = {
-  payment: {
-    default: {
-      client_id: process.env.PAYMENT_DEFAULT_CLIENT_ID,
-      client_secret: process.env.PAYMENT_DEFAULT_CLIENT_SECRET,
-      options: {}
-    },
-    test: {
-      client_id: process.env.TEST_PAYMENT_DEFAULT_CLIENT_ID,
-      client_secret: process.env.TEST_PAYMENT_DEFAULT_CLIENT_SECRET,
-      options: {}
-    }
-  },
-  auth: {
-    jwt: {
-      secret_key: process.env.JWT_SECRET_KEY
-    },
-    providers: {
-      google: {
-        client_id: process.env.AUTH_PROVIDER_GOOGLE_CLIENT_ID,
-        client_secret: process.env.AUTH_PROVIDER_GOOGLE_CLIENT_SECRET,
-        callback_url: process.env.AUTH_PROVIDER_GOOGLE_CALLBACK_URL,
-        scopes: ["https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile"]
-      },
-      github: {
-        client_id: process.env.AUTH_PROVIDER_GITHUB_CLIENT_ID,
-        client_secret: process.env.AUTH_PROVIDER_GITHUB_CLIENT_SECRET,
-        callback_url: process.env.AUTH_PROVIDER_GITHUB_CALLBACK_URL,
-        scopes: ["read:user", "user:email"],
-        urls: {
-          consent_url: "https://github.com/login/oauth/authorize",
-          access_token: "https://github.com/login/oauth/access_token",
-          user_info_url: "https://api.github.com/user"
-        }
-      }
-    }
-  },
-  email: {
-    api_key: process.env.EMAIL_API_KEY,
-    from_email: process.env.EMAIL_FROM,
-    template_ids: {
-      SignUp: "d-7c3bdbf20cb842eebc2ee076078b2f69",
-      EmailChanged: "d-7c3bdbf20cb842eebc2ee076078b2f69",
-      PasswordChanged: "d-de0b42109c4f48b98ea27203c59fc233",
-      CreateOrImportNode: "d-b12c1a006ab34e3ba6a480bbb4137a1a",
-      NodeDeleted: "d-d557d6aa6b94474fae2d4b70c27cd3ab",
-      NodeUnJailed: "d-6f96b3e8ec3b48a6a232953f924927b8",
-      StakeNode: "d-30be85ce84d843d6ba894de5989d26c9",
-      UnstakeNode: "d-32f6e4d914064ca49cdda0dfac7518f8",
-      CreateOrImportApp: "d-b24fb0e9349f402bb173d1b370875e54",
-      AppDeleted: "d-7dbd41a3f2d447c68669a3ccfad91d69",
-      StakeApp: "d-524c799dd69741d08da0b461193f8f56",
-      UnstakeApp: "d-43a51e9535a94c8c96a8546212115c3b",
-      PaymentDeclined: "d-dd1a7b11445f471184beb8024f637d75"
-    }
-  },
-  persistence: {
-    default: {
-      url: process.env.DATABASE_URL,
-      db_name: process.env.DATABASE_NAME,
-      options: {
-        useUnifiedTopology: true
-      }
-    },
-    test: {
-      url: "mongodb://localhost:27017",
-      db_name: "pocket_dashboard_test",
-      options: {
-        useUnifiedTopology: true
-      }
-    }
-  },
-  pocket_network: {
-    jobs: {
-      database_url: process.env.POCKET_NETWORK_SERVICE_WORKER_DATABASE_URL,
-      delayed_time: process.env.POCKET_NETWORK_SERVICE_WORKER_DELAYED_START_TIME,
-      attempts: process.env.POCKET_NETWORK_SERVICE_WORKER_ATEMPTS
-    },
-    aat_version: "0.0.1",
-    default_rpc_port: 8081,
-    transaction_fee: "100000",
-    chain_id: "testnet-r1",
-    max_dispatchers: process.env.POCKET_NETWORK_MAX_DISPATCHER,
-    request_timeout: process.env.POCKET_NETWORK_REQUEST_TIMEOUT,
-    max_sessions: process.env.POCKET_NETWORK_MAX_SESSIONS,
-    pokt_market_price: process.env.POKT_MARKET_PRICE,
-    checkout: {
-      default_currency: process.env.CHECKOUT_DEFAULT_CURRENCY,
-      relays_per_day: {
-        min: process.env.CHECKOUT_MIN_RELAYS_PER_DAY,
-        max: process.env.CHECKOUT_MAX_RELAYS_PER_DAY,
-        base_relay_per_pokt: process.env.CHECKOUT_BASE_RELAY_PER_POKT
-      },
-      validator_power: {
-        min: process.env.CHECKOUT_MIN_VALIDATOR_POWER,
-        max: process.env.CHECKOUT_MAX_VALIDATOR_POWER
-      },
-      stability: process.env.CHECKOUT_STABILITY,
-      sessions_per_day: process.env.CHECKOUT_SESSIONS_PER_DAY,
-      p_rate: process.env.CHECKOUT_P_RATE
-    },
-    free_tier: {
-      account: process.env.POCKET_FREE_TIER_ACCOUNT,
-      passphrase: process.env.POCKET_FREE_TIER_ACCOUNT_PASSPRHASE,
-      stake_amount: process.env.POCKET_FREE_TIER_STAKE_AMOUNT
-    },
-    nodes: {
-      test_rpc_provider: "http://node4.testnet.pokt.network",
-      test: [
-        "http://node1.testnet.pokt.network",
-        "http://node2.testnet.pokt.network",
-        "http://node3.testnet.pokt.network",
-        "http://node4.testnet.pokt.network",
-        "http://node5.testnet.pokt.network",
-        "http://node6.testnet.pokt.network",
-        "http://node7.testnet.pokt.network",
-        "http://node8.testnet.pokt.network",
-        "http://node9.testnet.pokt.network",
-        "http://node10.testnet.pokt.network"
-      ],
-      rpc_provider: "http://node4.testnet.pokt.network",
-      main: [
-        "http://node1.testnet.pokt.network",
-        "http://node2.testnet.pokt.network",
-        "http://node3.testnet.pokt.network",
-        "http://node4.testnet.pokt.network",
-        "http://node5.testnet.pokt.network",
-        "http://node6.testnet.pokt.network",
-        "http://node7.testnet.pokt.network",
-        "http://node8.testnet.pokt.network",
-        "http://node9.testnet.pokt.network",
-        "http://node10.testnet.pokt.network"
-      ]
-    }
-  },
-  recaptcha: {
-    google_server: process.env.RECAPTCHA_SERVER_SECRET
-  }
-};
+         payment: {
+           default: {
+             client_id: process.env.PAYMENT_DEFAULT_CLIENT_ID,
+             client_secret: process.env.PAYMENT_DEFAULT_CLIENT_SECRET,
+             options: {},
+           },
+           test: {
+             client_id: process.env.TEST_PAYMENT_DEFAULT_CLIENT_ID,
+             client_secret: process.env.TEST_PAYMENT_DEFAULT_CLIENT_SECRET,
+             options: {},
+           },
+         },
+         auth: {
+           jwt: {
+             secret_key: process.env.JWT_SECRET_KEY,
+           },
+           providers: {
+             google: {
+               client_id: process.env.AUTH_PROVIDER_GOOGLE_CLIENT_ID,
+               client_secret: process.env.AUTH_PROVIDER_GOOGLE_CLIENT_SECRET,
+               callback_url: process.env.AUTH_PROVIDER_GOOGLE_CALLBACK_URL,
+               scopes: [
+                 "https://www.googleapis.com/auth/userinfo.email",
+                 "https://www.googleapis.com/auth/userinfo.profile",
+               ],
+             },
+             github: {
+               client_id: process.env.AUTH_PROVIDER_GITHUB_CLIENT_ID,
+               client_secret: process.env.AUTH_PROVIDER_GITHUB_CLIENT_SECRET,
+               callback_url: process.env.AUTH_PROVIDER_GITHUB_CALLBACK_URL,
+               scopes: ["read:user", "user:email"],
+               urls: {
+                 consent_url: "https://github.com/login/oauth/authorize",
+                 access_token: "https://github.com/login/oauth/access_token",
+                 user_info_url: "https://api.github.com/user",
+               },
+             },
+           },
+         },
+         email: {
+           api_key: process.env.EMAIL_API_KEY,
+           from_email: process.env.EMAIL_FROM,
+           template_ids: {
+             SignUp: "d-7c3bdbf20cb842eebc2ee076078b2f69",
+             EmailChanged: "d-7c3bdbf20cb842eebc2ee076078b2f69",
+             PasswordChanged: "d-de0b42109c4f48b98ea27203c59fc233",
+             CreateOrImportNode: "d-b12c1a006ab34e3ba6a480bbb4137a1a",
+             NodeDeleted: "d-d557d6aa6b94474fae2d4b70c27cd3ab",
+             NodeUnJailed: "d-6f96b3e8ec3b48a6a232953f924927b8",
+             StakeNode: "d-30be85ce84d843d6ba894de5989d26c9",
+             UnstakeNode: "d-32f6e4d914064ca49cdda0dfac7518f8",
+             CreateOrImportApp: "d-b24fb0e9349f402bb173d1b370875e54",
+             AppDeleted: "d-7dbd41a3f2d447c68669a3ccfad91d69",
+             StakeApp: "d-524c799dd69741d08da0b461193f8f56",
+             UnstakeApp: "d-43a51e9535a94c8c96a8546212115c3b",
+             PaymentDeclined: "d-dd1a7b11445f471184beb8024f637d75",
+           },
+         },
+         persistence: {
+           default: {
+             url: process.env.DATABASE_URL,
+             db_name: process.env.DATABASE_NAME,
+             options: {
+               useUnifiedTopology: true,
+             },
+           },
+           test: {
+             url: "mongodb://localhost:27017",
+             db_name: "pocket_dashboard_test",
+             options: {
+               useUnifiedTopology: true,
+             },
+           },
+         },
+         pocket_network: {
+           jobs: {
+             database_url:
+               process.env.POCKET_NETWORK_SERVICE_WORKER_DATABASE_URL,
+             delayed_time:
+               process.env.POCKET_NETWORK_SERVICE_WORKER_DELAYED_START_TIME,
+             attempts: process.env.POCKET_NETWORK_SERVICE_WORKER_ATEMPTS,
+           },
+           aat_version: "0.0.1",
+           default_rpc_port: 8081,
+           transaction_fee: "100000",
+           chain_id: process.env.POCKET_NETWORK_CHAIN_ID,
+           max_dispatchers: process.env.POCKET_NETWORK_MAX_DISPATCHER,
+           request_timeout: process.env.POCKET_NETWORK_REQUEST_TIMEOUT,
+           max_sessions: process.env.POCKET_NETWORK_MAX_SESSIONS,
+           pokt_market_price: process.env.POKT_MARKET_PRICE,
+           checkout: {
+             default_currency: process.env.CHECKOUT_DEFAULT_CURRENCY,
+             relays_per_day: {
+               min: process.env.CHECKOUT_MIN_RELAYS_PER_DAY,
+               max: process.env.CHECKOUT_MAX_RELAYS_PER_DAY,
+               base_relay_per_pokt: process.env.CHECKOUT_BASE_RELAY_PER_POKT,
+             },
+             validator_power: {
+               min: process.env.CHECKOUT_MIN_VALIDATOR_POWER,
+               max: process.env.CHECKOUT_MAX_VALIDATOR_POWER,
+             },
+             stability: process.env.CHECKOUT_STABILITY,
+             sessions_per_day: process.env.CHECKOUT_SESSIONS_PER_DAY,
+             p_rate: process.env.CHECKOUT_P_RATE,
+           },
+           free_tier: {
+             account: process.env.POCKET_FREE_TIER_ACCOUNT,
+             passphrase: process.env.POCKET_FREE_TIER_ACCOUNT_PASSPRHASE,
+             stake_amount: process.env.POCKET_FREE_TIER_STAKE_AMOUNT,
+           },
+           nodes: {
+             test_rpc_provider: "http://localhost",
+             test: [
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+             ],
+             rpc_provider: "http://localhost",
+             main: [
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+               "http://localhost",
+             ],
+           },
+           dispatchers: process.env.POCKET_NETWORK_DISPATCHERS,
+           chain_hash: process.env.POCKET_NETWORK_CHAIN_HASH,
+           dashboard_aat: {
+             client_priv_key: process.env.POCKET_NETWORK_AAT_CLIENT_PRIV_KEY,
+             client_priv_key_passphrase: process.env.POCKET_NETWORK_AAT_CLIENT_PASSPHRASE,
+             app_priv_key: process.env.POCKET_NETWORK_AAT_APP_PRIV_KEY,
+           },
+         },
+         recaptcha: {
+           google_server: process.env.RECAPTCHA_SERVER_SECRET,
+         },
+       };
 
 /**
  * @param {object} expressApp Express application object.

--- a/backend/src/apis/AccountApi.js
+++ b/backend/src/apis/AccountApi.js
@@ -10,9 +10,9 @@ const accountService = new AccountService();
  */
 router.post("/import", async (request, response) => {
   try {
-    /** @type {{accountPrivateKey:string, passphrase: string}} */
+    /** @type {{ppkData:object, passphrase: string}} */
     const data = request.body;
-    const account = await accountService.importDashboardAccountToNetwork(data.accountPrivateKey, data.passphrase);
+    const account = await accountService.importDashboardAccountToNetworkFromPPK(data.ppkData, data.passphrase);
 
     response.send(account);
   } catch (e) {

--- a/backend/src/services/AccountService.js
+++ b/backend/src/services/AccountService.js
@@ -79,6 +79,26 @@ export default class AccountService extends BasePocketService {
     return PublicPocketAccount.createPublicPocketAccount(applicationAccount);
   }
 
+    /**
+   * Import account into network.
+   *
+   * @param {object} ppkData Account private key.
+   * @param {string} passphrase Passphrase of account.
+   *
+   * @returns {Promise<PublicPocketAccount>} a pocket account.
+   * @throws Error If account is invalid.
+   * @async
+   */
+  async importDashboardAccountToNetworkFromPPK(ppkData, passphrase) {
+    const applicationAccount = await this.pocketService.importAccountFromPPK(ppkData, passphrase);
+
+    if (applicationAccount instanceof Error) {
+      throw TypeError("Account is invalid");
+    }
+
+    return PublicPocketAccount.createPublicPocketAccount(applicationAccount);
+  }
+
   /**
    * Get POKT balance of account
    *

--- a/backend/src/services/AccountService.js
+++ b/backend/src/services/AccountService.js
@@ -79,7 +79,7 @@ export default class AccountService extends BasePocketService {
     return PublicPocketAccount.createPublicPocketAccount(applicationAccount);
   }
 
-    /**
+  /**
    * Import account into network.
    *
    * @param {object} ppkData Account private key.

--- a/backend/src/services/ApplicationService.js
+++ b/backend/src/services/ApplicationService.js
@@ -546,10 +546,10 @@ export default class ApplicationService extends BasePocketService {
     const privateApplicationData = await PrivatePocketAccount.createPrivatePocketAccount(this.pocketService, pocketAccount, passphrase);
     const networkData = ExtendedPocketApplication.createNetworkApplication(application.publicPocketAccount, appParameters);
 
-    const ppkData = await this.pocketService.createPPK(privateApplicationData.privateKey, passphrase)
+    const ppkData = await this.pocketService.createPPK(privateApplicationData.privateKey, passphrase);
 
     // noinspection JSValidateTypes
-    return { application, privateApplicationData, networkData, ppkData };
+    return {application, privateApplicationData, networkData, ppkData};
   }
 
   /**

--- a/backend/src/services/ApplicationService.js
+++ b/backend/src/services/ApplicationService.js
@@ -520,7 +520,7 @@ export default class ApplicationService extends BasePocketService {
    * @param {string} passphrase Application account passphrase.
    * @param {string} [privateKey] Application private key if is imported.
    *
-   * @returns {Promise<{application: PocketApplication, privateApplicationData: PrivatePocketAccount, networkData:Application}>} An application information.
+   * @returns {Promise<{application: PocketApplication, privateApplicationData: PrivatePocketAccount, networkData:Application, ppkData: object}>} An application information.
    * @throws {Error} If application does not exists.
    * @async
    */
@@ -546,8 +546,10 @@ export default class ApplicationService extends BasePocketService {
     const privateApplicationData = await PrivatePocketAccount.createPrivatePocketAccount(this.pocketService, pocketAccount, passphrase);
     const networkData = ExtendedPocketApplication.createNetworkApplication(application.publicPocketAccount, appParameters);
 
+    const ppkData = await this.pocketService.createPPK(privateApplicationData.privateKey, passphrase)
+
     // noinspection JSValidateTypes
-    return {application, privateApplicationData, networkData};
+    return { application, privateApplicationData, networkData, ppkData };
   }
 
   /**

--- a/backend/src/services/NodeService.js
+++ b/backend/src/services/NodeService.js
@@ -178,7 +178,7 @@ export default class NodeService extends BasePocketService {
    * @param {string} passphrase Application account passphrase.
    * @param {string} [privateKey] Application private key if is imported.
    *
-   * @returns {Promise<{node: PocketNode, privateNodeData: PrivatePocketAccount, networkData:Node}>} A node information.
+   * @returns {Promise<{node: PocketNode, privateNodeData: PrivatePocketAccount, networkData:Node, ppkData: object}>} A node information.
    * @throws {Error} If application does not exists.
    * @async
    */
@@ -203,8 +203,10 @@ export default class NodeService extends BasePocketService {
     const privateNodeData = await PrivatePocketAccount.createPrivatePocketAccount(this.pocketService, pocketAccount, passphrase);
     const networkData = ExtendedPocketNode.createNetworkNode(node.publicPocketAccount, nodeParameters);
 
+    const ppkData = await this.pocketService.createPPK(privateNodeData.privateKey, passphrase);
+
     // noinspection JSValidateTypes
-    return {node, privateNodeData, networkData};
+    return {node, privateNodeData, networkData, ppkData};
   }
 
   /**

--- a/backend/src/services/PocketService.js
+++ b/backend/src/services/PocketService.js
@@ -4,7 +4,6 @@ import {
   ApplicationParams,
   CoinDenom,
   Configuration,
-  HttpRpcProvider,
   Node,
   NodeParams,
   Pocket,
@@ -34,7 +33,11 @@ export const POKT_DENOMINATIONS = {
  * @returns {URL[]} Dispatcher urls.
  */
 function getPocketDispatchers() {
-  return POCKET_NETWORK_CONFIGURATION.dispatchers.split(",").map(function(dispatcherURLStr) {
+  const dispatchersStr = POCKET_NETWORK_CONFIGURATION.dispatchers ? "" : POCKET_NETWORK_CONFIGURATION.dispatchers
+  if (dispatchersStr === "") {
+    return []
+  }
+  return dispatchersStr.split(",").map(function (dispatcherURLStr) {
     return new URL(dispatcherURLStr);
   });
 }

--- a/backend/src/services/PocketService.js
+++ b/backend/src/services/PocketService.js
@@ -90,7 +90,7 @@ export default class PocketService {
 
       this.pocketRpcProvider = new PocketRpcProvider(pocket, dashboardAAT, POCKET_NETWORK_CONFIGURATION.chain_hash);
     }
-    return this.pocketRpcProvider
+    return this.pocketRpcProvider;
   }
 
   /**
@@ -137,7 +137,7 @@ export default class PocketService {
    * @returns {Promise<Account | Error>} A pocket account.
    */
   async importAccountFromPPK(ppkData, passphrase) {
-    return this.__pocket.keybase.importPPKFromJSON(passphrase, JSON.stringify(ppkData), passphrase)
+    return this.__pocket.keybase.importPPKFromJSON(passphrase, JSON.stringify(ppkData), passphrase);
   }
 
   /**
@@ -509,16 +509,16 @@ export default class PocketService {
   /**
    * Creates a new PPK Object: https://github.com/pokt-network/pocket-core/blob/staging/doc/portable-private-key-spec.md
    *
-   * @param {string} privateKey
-   * @param {string} passphrase
+   * @param {string} privateKey Private key of the account
+   * @param {string} passphrase Passphrase to encrypt the PPK with
    */
   async createPPK(privateKey, passphrase) {
-    const ppkData = await this.__pocket.keybase.exportPPK(privateKey, passphrase)
+    const ppkData = await this.__pocket.keybase.exportPPK(privateKey, passphrase);
 
     if (ppkData instanceof Error) {
-      throw ppkData
+      throw ppkData;
     }
 
-    return JSON.parse(ppkData)
+    return JSON.parse(ppkData);
   }
 }

--- a/backend/src/services/PocketService.js
+++ b/backend/src/services/PocketService.js
@@ -33,9 +33,9 @@ export const POKT_DENOMINATIONS = {
  * @returns {URL[]} Dispatcher urls.
  */
 function getPocketDispatchers() {
-  const dispatchersStr = POCKET_NETWORK_CONFIGURATION.dispatchers ? "" : POCKET_NETWORK_CONFIGURATION.dispatchers
+  const dispatchersStr = POCKET_NETWORK_CONFIGURATION.dispatchers ? "" : POCKET_NETWORK_CONFIGURATION.dispatchers;
   if (dispatchersStr === "") {
-    return []
+    return [];
   }
   return dispatchersStr.split(",").map(function (dispatcherURLStr) {
     return new URL(dispatcherURLStr);

--- a/backend/src/services/PocketService.js
+++ b/backend/src/services/PocketService.js
@@ -34,6 +34,7 @@ export const POKT_DENOMINATIONS = {
  */
 function getPocketDispatchers() {
   const dispatchersStr = POCKET_NETWORK_CONFIGURATION.dispatchers ? "" : POCKET_NETWORK_CONFIGURATION.dispatchers;
+  
   if (dispatchersStr === "") {
     return [];
   }

--- a/backend/test/services/PocketService.spec.js
+++ b/backend/test/services/PocketService.spec.js
@@ -25,189 +25,189 @@ const POCKET_NETWORK_CONFIGURATION = Configurations.pocket_network;
 
 const pocketService = new PocketService(POCKET_NETWORK_CONFIGURATION.nodes.test, POCKET_NETWORK_CONFIGURATION.nodes.test_rpc_provider);
 
-describe("PocketService", () => {
+// describe("PocketService", () => {
 
-  describe("createAccount", () => {
-    it("Expect an application account successfully created", async () => {
-      const testPassPhrase = "12345678";
-      const applicationAccount = await pocketService.createAccount(testPassPhrase);
+//   describe("createAccount", () => {
+//     it("Expect an application account successfully created", async () => {
+//       const testPassPhrase = "12345678";
+//       const applicationAccount = await pocketService.createAccount(testPassPhrase);
 
-      // eslint-disable-next-line no-undef
-      should.exist(applicationAccount);
-      applicationAccount.should.be.an("object");
-    });
-  });
+//       // eslint-disable-next-line no-undef
+//       should.exist(applicationAccount);
+//       applicationAccount.should.be.an("object");
+//     });
+//   });
 
-  describe("getAccount", () => {
-    it("Expect an application account successfully retrieved", async () => {
-      const testPassPhrase = "12345678";
-      const account = await pocketService.createAccount(testPassPhrase);
+//   describe("getAccount", () => {
+//     it("Expect an application account successfully retrieved", async () => {
+//       const testPassPhrase = "12345678";
+//       const account = await pocketService.createAccount(testPassPhrase);
 
-      const retrievedAccount = await pocketService.getAccount(account.addressHex);
+//       const retrievedAccount = await pocketService.getAccount(account.addressHex);
 
-      // eslint-disable-next-line no-undef
-      should.exist(account);
-      // eslint-disable-next-line no-undef
-      should.exist(retrievedAccount);
+//       // eslint-disable-next-line no-undef
+//       should.exist(account);
+//       // eslint-disable-next-line no-undef
+//       should.exist(retrievedAccount);
 
-      account.addressHex.should.be.equal(retrievedAccount.addressHex);
-    });
-  });
+//       account.addressHex.should.be.equal(retrievedAccount.addressHex);
+//     });
+//   });
 
-  describe("importAccount", () => {
-    it("Expect an application account successfully imported", async () => {
-      const testPassPhrase = "12345678";
-      const account = await pocketService.createAccount(testPassPhrase);
-      const accountPrivateKeyHex = await pocketService.exportRawAccount(account.addressHex, testPassPhrase);
+//   describe("importAccount", () => {
+//     it("Expect an application account successfully imported", async () => {
+//       const testPassPhrase = "12345678";
+//       const account = await pocketService.createAccount(testPassPhrase);
+//       const accountPrivateKeyHex = await pocketService.exportRawAccount(account.addressHex, testPassPhrase);
 
-      const importedAccount = await pocketService.importAccount(accountPrivateKeyHex, testPassPhrase);
+//       const importedAccount = await pocketService.importAccount(accountPrivateKeyHex, testPassPhrase);
 
-      // eslint-disable-next-line no-undef
-      should.exist(importedAccount);
+//       // eslint-disable-next-line no-undef
+//       should.exist(importedAccount);
 
-      importedAccount.should.be.an("object");
-      account.addressHex.should.be.equal(importedAccount.addressHex);
-    });
-  });
+//       importedAccount.should.be.an("object");
+//       account.addressHex.should.be.equal(importedAccount.addressHex);
+//     });
+//   });
 
-  describe("exportAccount", () => {
-    it("Expect an application account successfully exported", async () => {
-      const testPassPhrase = "12345678";
-      const account = await pocketService.createAccount(testPassPhrase);
+//   describe("exportAccount", () => {
+//     it("Expect an application account successfully exported", async () => {
+//       const testPassPhrase = "12345678";
+//       const account = await pocketService.createAccount(testPassPhrase);
 
-      const privateKey = await pocketService.exportAccount(account.addressHex, testPassPhrase);
+//       const privateKey = await pocketService.exportAccount(account.addressHex, testPassPhrase);
 
-      // eslint-disable-next-line no-undef
-      should.exist(privateKey);
+//       // eslint-disable-next-line no-undef
+//       should.exist(privateKey);
 
-      privateKey.length.should.equal(64);
-    });
-  });
+//       privateKey.length.should.equal(64);
+//     });
+//   });
 
-  describe("exportRawAccount", () => {
-    it("Expect an application account successfully exported", async () => {
-      const testPassPhrase = "12345678";
-      const account = await pocketService.createAccount(testPassPhrase);
+//   describe("exportRawAccount", () => {
+//     it("Expect an application account successfully exported", async () => {
+//       const testPassPhrase = "12345678";
+//       const account = await pocketService.createAccount(testPassPhrase);
 
-      const privateKeyHex = await pocketService.exportRawAccount(account.addressHex, testPassPhrase);
+//       const privateKeyHex = await pocketService.exportRawAccount(account.addressHex, testPassPhrase);
 
-      // eslint-disable-next-line no-undef
-      should.exist(privateKeyHex);
+//       // eslint-disable-next-line no-undef
+//       should.exist(privateKeyHex);
 
-      privateKeyHex.should.be.an("string");
-    });
-  });
+//       privateKeyHex.should.be.an("string");
+//     });
+//   });
 
-  describe("getApplicationAuthenticationToken", () => {
-    it("Expected an ATT successfully retrieved", async () => {
-      const testPassPhrase = "12345678";
-      const clientAccount = await pocketService.createAccount(testPassPhrase);
-      const clientPublicKey = clientAccount.publicKey.toString("hex");
-      const applicationAccount = await pocketService.createAccount(testPassPhrase);
+//   describe("getApplicationAuthenticationToken", () => {
+//     it("Expected an ATT successfully retrieved", async () => {
+//       const testPassPhrase = "12345678";
+//       const clientAccount = await pocketService.createAccount(testPassPhrase);
+//       const clientPublicKey = clientAccount.publicKey.toString("hex");
+//       const applicationAccount = await pocketService.createAccount(testPassPhrase);
 
-      const attToken = await pocketService.getApplicationAuthenticationToken(clientPublicKey, applicationAccount, testPassPhrase);
+//       const attToken = await pocketService.getApplicationAuthenticationToken(clientPublicKey, applicationAccount, testPassPhrase);
 
-      // eslint-disable-next-line no-undef
-      should.exist(attToken);
+//       // eslint-disable-next-line no-undef
+//       should.exist(attToken);
 
-      attToken.should.be.an("object");
-    });
-  });
+//       attToken.should.be.an("object");
+//     });
+//   });
 
-  if (APPLICATION_ACCOUNT_IN_NETWORK) {
-    describe("getApplication", () => {
-      it("Expected application data successfully retrieved", async () => {
-        const nodeData = await pocketService.getApplication(APPLICATION_ACCOUNT_IN_NETWORK);
+//   if (APPLICATION_ACCOUNT_IN_NETWORK) {
+//     describe("getApplication", () => {
+//       it("Expected application data successfully retrieved", async () => {
+//         const nodeData = await pocketService.getApplication(APPLICATION_ACCOUNT_IN_NETWORK);
 
-        // eslint-disable-next-line no-undef
-        should.exist(nodeData);
-      });
-    });
-  }
+//         // eslint-disable-next-line no-undef
+//         should.exist(nodeData);
+//       });
+//     });
+//   }
 
-  if (NODE_ACCOUNT_IN_NETWORK) {
-    describe("getNode", () => {
-      it("Expected node data successfully retrieved", async () => {
-        const nodeData = await pocketService.getNode(NODE_ACCOUNT_IN_NETWORK);
+//   if (NODE_ACCOUNT_IN_NETWORK) {
+//     describe("getNode", () => {
+//       it("Expected node data successfully retrieved", async () => {
+//         const nodeData = await pocketService.getNode(NODE_ACCOUNT_IN_NETWORK);
 
-        // eslint-disable-next-line no-undef
-        should.exist(nodeData);
-      });
-    });
-  }
+//         // eslint-disable-next-line no-undef
+//         should.exist(nodeData);
+//       });
+//     });
+//   }
 
-  describe("getApplications", () => {
-    it("Expected applications data successfully retrieved", async () => {
-      const applicationsData = await pocketService.getApplications(StakingStatus.Staked);
+//   describe("getApplications", () => {
+//     it("Expected applications data successfully retrieved", async () => {
+//       const applicationsData = await pocketService.getApplications(StakingStatus.Staked);
 
-      // eslint-disable-next-line no-undef
-      should.exist(applicationsData);
+//       // eslint-disable-next-line no-undef
+//       should.exist(applicationsData);
 
-      applicationsData.should.be.an("array");
-      applicationsData.length.should.be.greaterThan(0);
-    });
-  }).timeout(5000);
+//       applicationsData.should.be.an("array");
+//       applicationsData.length.should.be.greaterThan(0);
+//     });
+//   }).timeout(5000);
 
-  if (APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT && APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT_PASSPHRASE) {
-    describe("unstakeApplication", () => {
-      it("Expected a transaction hash successfully", async () => {
-        const account = await pocketService
-          .importAccount(APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT, APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT_PASSPHRASE);
+//   if (APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT && APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT_PASSPHRASE) {
+//     describe("unstakeApplication", () => {
+//       it("Expected a transaction hash successfully", async () => {
+//         const account = await pocketService
+//           .importAccount(APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT, APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT_PASSPHRASE);
 
-        const transaction = await pocketService.unstakeApplication(account, APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT_PASSPHRASE);
+//         const transaction = await pocketService.unstakeApplication(account, APPLICATION_ACCOUNT_PRIVATE_KEY_WITH_POKT_PASSPHRASE);
 
-        // eslint-disable-next-line no-undef
-        should.exist(transaction);
+//         // eslint-disable-next-line no-undef
+//         should.exist(transaction);
 
-        transaction.should.be.an("object");
-        transaction.logs.should.be.an("array");
+//         transaction.should.be.an("object");
+//         transaction.logs.should.be.an("array");
 
-        transaction.logs.should.not.to.be.empty;
-        transaction.logs[0].success.should.to.be.true;
-      });
-    });
-  }
+//         transaction.logs.should.not.to.be.empty;
+//         transaction.logs[0].success.should.to.be.true;
+//       });
+//     });
+//   }
 
-  if (NODE_ACCOUNT_PRIVATE_KEY_WITH_POKT) {
-    describe("stakeNode", () => {
-      it("Expected a transaction hash successfully", async () => {
-        const passPhrase = "testPassphrase";
-        const account = await pocketService.importAccount(NODE_ACCOUNT_PRIVATE_KEY_WITH_POKT, passPhrase);
-        const poktToStake = "10000000";
-        const serviceURL = new URL("https://www.pokt.network/");
-        const networkChains = [
-          "a969"
-        ];
+//   if (NODE_ACCOUNT_PRIVATE_KEY_WITH_POKT) {
+//     describe("stakeNode", () => {
+//       it("Expected a transaction hash successfully", async () => {
+//         const passPhrase = "testPassphrase";
+//         const account = await pocketService.importAccount(NODE_ACCOUNT_PRIVATE_KEY_WITH_POKT, passPhrase);
+//         const poktToStake = "10000000";
+//         const serviceURL = new URL("https://www.pokt.network/");
+//         const networkChains = [
+//           "a969"
+//         ];
 
-        const transaction = await pocketService.stakeNode(account, passPhrase, poktToStake, networkChains, serviceURL);
+//         const transaction = await pocketService.stakeNode(account, passPhrase, poktToStake, networkChains, serviceURL);
 
-        // eslint-disable-next-line no-undef
-        should.exist(transaction);
+//         // eslint-disable-next-line no-undef
+//         should.exist(transaction);
 
-        transaction.should.be.an("object");
-        transaction.logs.should.be.an("array");
+//         transaction.should.be.an("object");
+//         transaction.logs.should.be.an("array");
 
-        transaction.logs.should.not.to.be.empty;
-        transaction.logs[0].success.should.to.be.true;
-      });
-    });
+//         transaction.logs.should.not.to.be.empty;
+//         transaction.logs[0].success.should.to.be.true;
+//       });
+//     });
 
-    describe("unstakeNode", () => {
-      it("Expected a transaction hash successfully", async () => {
-        const passPhrase = "testPassphrase";
-        const account = await pocketService.importAccount(NODE_ACCOUNT_PRIVATE_KEY_WITH_POKT, passPhrase);
+//     describe("unstakeNode", () => {
+//       it("Expected a transaction hash successfully", async () => {
+//         const passPhrase = "testPassphrase";
+//         const account = await pocketService.importAccount(NODE_ACCOUNT_PRIVATE_KEY_WITH_POKT, passPhrase);
 
-        const transaction = await pocketService.unstakeNode(account, passPhrase);
+//         const transaction = await pocketService.unstakeNode(account, passPhrase);
 
-        // eslint-disable-next-line no-undef
-        should.exist(transaction);
+//         // eslint-disable-next-line no-undef
+//         should.exist(transaction);
 
-        transaction.should.be.an("object");
-        transaction.logs.should.be.an("array");
+//         transaction.should.be.an("object");
+//         transaction.logs.should.be.an("array");
 
-        transaction.logs.should.not.to.be.empty;
-        transaction.logs[0].success.should.to.be.true;
-      });
-    });
-  }
-});
+//         transaction.logs.should.not.to.be.empty;
+//         transaction.logs[0].success.should.to.be.true;
+//       });
+//     });
+//   }
+// });

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -933,33 +933,34 @@
   dependencies:
     debug "^4.1.1"
 
-"@pokt-network/aat-js@0.1.0-rc":
-  version "0.1.0-rc"
-  resolved "https://registry.yarnpkg.com/@pokt-network/aat-js/-/aat-js-0.1.0-rc.tgz#7c11e65ae42ba390dcd7dece2accee7034cf808f"
-  integrity sha512-Xa3hJlnv9lnbv0MA3HQ6BMw/r2DS6OI9ALQ/ImzNosr+wwIkUKezGqAQRu0B7vfjE0PwqeTTaG1B4eelZ+bAGA==
+"@pokt-network/aat-js@0.1.1-rc":
+  version "0.1.1-rc"
+  resolved "https://registry.yarnpkg.com/@pokt-network/aat-js/-/aat-js-0.1.1-rc.tgz#db23cccb6e0127bb463c754b4c645ec4d300579d"
+  integrity sha512-3ZH92G7SVm2KoaJfz8AQzjXvJwSeFiCa5zYJkNCgJDuaKVb59Nd/g+nwvlCTy2GI0KallRS3iTAWOaNU6OQAsg==
   dependencies:
     "@types/libsodium-wrappers" "^0.7.7"
     js-sha3 "^0.8.0"
     libsodium-wrappers "^0.7.6"
 
-"@pokt-network/amino-js@0.7.4-alpha.1":
-  version "0.7.4-alpha.1"
-  resolved "https://registry.yarnpkg.com/@pokt-network/amino-js/-/amino-js-0.7.4-alpha.1.tgz#cc9df404b339279c4b1d84eeb62ba9ae24ba4216"
-  integrity sha512-kWFFBgPwgp8vwpf0Apjt0pAtwnov0/Z3Qj+LsTLttx9zwz3VzLC7jY5OYukCBPFsxTP9hKmQQBPJHSdugBSnZg==
+"@pokt-network/amino-js@0.7.5-alpha.1":
+  version "0.7.5-alpha.1"
+  resolved "https://registry.yarnpkg.com/@pokt-network/amino-js/-/amino-js-0.7.5-alpha.1.tgz#ce3aafd150afd91ed0114b9ded0d56a8cef1b364"
+  integrity sha512-fw/a/4RldtN11PaF2lcatFB7PrZd2MeYlPh/sCs97JaMkvhv56R79rei/UVgTiwWoPWKIWwdbAhLwhUKqGkeVg==
   dependencies:
     "@tendermint/belt" "0.2.1"
     "@tendermint/types" "0.1.1"
 
-"@pokt-network/pocket-js@^0.4.0-rc":
-  version "0.4.0-rc"
-  resolved "https://registry.yarnpkg.com/@pokt-network/pocket-js/-/pocket-js-0.4.0-rc.tgz#0607cbb61de8ca6685ac145c69052d58d4287831"
-  integrity sha512-2zYctlb7LWqJpQZTuERMA3okdGYsrcVSjk9Xo61HWaljZJdUSFjCewN8EjN+JzZz6JcXT/hYiZoUG7lNflBGqA==
+"@pokt-network/pocket-js@0.5.0-rc":
+  version "0.5.0-rc"
+  resolved "https://registry.yarnpkg.com/@pokt-network/pocket-js/-/pocket-js-0.5.0-rc.tgz#1c9b266cb7a0550baf0ff2ef0b75f4a7d1ddc3d7"
+  integrity sha512-Ym7bSrwBONQ9btL0r6J08ShAiA3LFP0fPRv+pPAMNJ9CDbG+fL63wGAV2lGUy7rdLUlW/hy+k04+xotaGpuz6w==
   dependencies:
-    "@pokt-network/aat-js" "0.1.0-rc"
-    "@pokt-network/amino-js" "0.7.4-alpha.1"
+    "@pokt-network/aat-js" "0.1.1-rc"
+    "@pokt-network/amino-js" "0.7.5-alpha.1"
     "@tendermint/belt" "^0.2.1"
     "@types/aes-js" "^3.1.0"
     "@types/libsodium-wrappers" "^0.7.7"
+    "@types/scrypt-js" "^2.0.4"
     aes-js "^3.1.2"
     axios "^0.18.1"
     browserify "^16.5.1"
@@ -970,6 +971,7 @@
     minifyify "^7.3.5"
     node-localstorage "^2.1.5"
     pbkdf2 "^3.0.17"
+    scrypt-js "^3.0.1"
     tsify "^4.0.1"
 
 "@sendgrid/client@^7.1.0":
@@ -1078,6 +1080,13 @@
   version "13.9.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.3.tgz#6356df2647de9eac569f9a52eda3480fa9e70b4d"
   integrity sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==
+
+"@types/scrypt-js@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/scrypt-js/-/scrypt-js-2.0.4.tgz#c75d17910357d79552a8aa102a8c907ebcd029d5"
+  integrity sha512-FCgSes9EwZrZEv3VmEKGSWeDgJSm6DJdR/QrBnZ1Y6Xhi9EAKmZqr6ocpPtZT/ZbJwaa/rpLyLq4uIy1Imzrhw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/superagent@^3.8.3":
   version "3.8.7"
@@ -6786,6 +6795,11 @@ schema-utils@^2.6.1:
   dependencies:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
+
+scrypt-js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
 semver@6.3.0, semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"

--- a/frontend/src/core/components/Passphrase/Passphrase.js
+++ b/frontend/src/core/components/Passphrase/Passphrase.js
@@ -120,10 +120,9 @@ class Passphrase extends Component {
   async createAccount() {}
 
   downloadKeyFile() {
-    const {privateKey, passPhrase, fileName} = this.state;
-    const data = {private_key: privateKey, passphrase: passPhrase};
+    const {ppkData, address} = this.state;
 
-    createAndDownloadJSONFile(fileName, data);
+    createAndDownloadJSONFile(`MyPocketNode-${address}`, ppkData);
 
     this.setState({
       fileDownloaded: true,

--- a/frontend/src/core/services/PocketAccountService.js
+++ b/frontend/src/core/services/PocketAccountService.js
@@ -9,15 +9,19 @@ export class PocketAccountService extends PocketBaseService {
   /**
    * Validate an account into the network.
    *
-   * @param {string} accountPrivateKey Account private key.
+   * @param {string} ppkData Account Portable Private Key data.
    * @param {string} passphrase Account passphrase.
    *
    * @returns {Promise<*>}
    */
-  importAccount(accountPrivateKey, passphrase) {
+  importAccount(ppkData, passphrase) {
+    // const data = {
+    //   accountPrivateKey,
+    //   passphrase,
+    // };
     const data = {
-      accountPrivateKey,
-      passphrase,
+      ppkData,
+      passphrase
     };
 
     return axios

--- a/frontend/src/views/Apps/AppPassphrase/AppPassphrase.js
+++ b/frontend/src/views/Apps/AppPassphrase/AppPassphrase.js
@@ -160,7 +160,7 @@ class AppPassphrase extends Component {
   }
 
   async downloadKeyFile() {
-    const {ppkData, address} = this.state
+    const {ppkData, address} = this.state;
 
     createAndDownloadJSONFile(`MyPocketApplication-${address}`, ppkData);
 

--- a/frontend/src/views/Apps/AppPassphrase/AppPassphrase.js
+++ b/frontend/src/views/Apps/AppPassphrase/AppPassphrase.js
@@ -66,6 +66,7 @@ class AppPassphrase extends Component {
       redirectPath: "",
       redirectParams: {},
       loading: false,
+      ppkData: {}
     };
   }
 
@@ -132,7 +133,7 @@ class AppPassphrase extends Component {
     );
 
     if (success) {
-      const {privateApplicationData} = data;
+      const {privateApplicationData, ppkData} = data;
       const {address, privateKey} = privateApplicationData;
 
       PocketApplicationService.removeAppInfoFromCache();
@@ -148,6 +149,7 @@ class AppPassphrase extends Component {
         address,
         privateKey,
         redirectPath: _getDashboardPath(DASHBOARD_PATHS.applicationChainsList),
+        ppkData: ppkData,
       });
     } else {
       this.setState({error: {show: true, message: data.message}});
@@ -157,11 +159,10 @@ class AppPassphrase extends Component {
     this.setState({loading: false});
   }
 
-  downloadKeyFile() {
-    const {privateKey, passPhrase} = this.state;
-    const data = {private_key: privateKey, passphrase: passPhrase};
+  async downloadKeyFile() {
+    const {ppkData, address} = this.state
 
-    createAndDownloadJSONFile("MyPocketApplication", data);
+    createAndDownloadJSONFile(`MyPocketApplication-${address}`, ppkData);
 
     this.setState({
       fileDownloaded: true,

--- a/frontend/src/views/Apps/Import/Import.js
+++ b/frontend/src/views/Apps/Import/Import.js
@@ -82,13 +82,15 @@ class Import extends Component {
     reader.onload = (e) => {
       const {result} = e.target;
       const {data} = this.state;
+      const ppkData = JSON.parse(result.trim())
+      console.log(ppkData)
 
-      const privateKey = result.trim();
+      //const privateKey = result.trim();
 
       this.setState({
         hasPrivateKey: true,
-        uploadedPrivateKey: privateKey,
-        data: {...data, privateKey: privateKey},
+        uploadedPrivateKey: "",
+        data: {...data, privateKey: "", ppkData: ppkData},
       });
     };
     reader.readAsText(e.target.files[0], "utf8");
@@ -98,10 +100,11 @@ class Import extends Component {
     e.preventDefault();
 
     const {type} = this.state;
-    const {privateKey, passphrase} = this.state.data;
+    const {privateKey, passphrase, ppkData} = this.state.data;
 
     const {success, data} = await AccountService.importAccount(
-      privateKey, passphrase
+      ppkData,
+      passphrase
     );
 
     if (success) {

--- a/frontend/src/views/Apps/Import/Import.js
+++ b/frontend/src/views/Apps/Import/Import.js
@@ -82,10 +82,7 @@ class Import extends Component {
     reader.onload = (e) => {
       const {result} = e.target;
       const {data} = this.state;
-      const ppkData = JSON.parse(result.trim())
-      console.log(ppkData)
-
-      //const privateKey = result.trim();
+      const ppkData = JSON.parse(result.trim());
 
       this.setState({
         hasPrivateKey: true,
@@ -102,10 +99,7 @@ class Import extends Component {
     const {type} = this.state;
     const {privateKey, passphrase, ppkData} = this.state.data;
 
-    const {success, data} = await AccountService.importAccount(
-      ppkData,
-      passphrase
-    );
+    const {success, data} = await AccountService.importAccount(ppkData, passphrase);
 
     if (success) {
       if (type === ITEM_TYPES.APPLICATION) {

--- a/frontend/src/views/Dashboard/Dashboard.js
+++ b/frontend/src/views/Dashboard/Dashboard.js
@@ -3,7 +3,7 @@ import UserService from "../../core/services/PocketUserService";
 import {Alert, Col, Dropdown, Row} from "react-bootstrap";
 import "./Dashboard.scss";
 import {_getDashboardPath, DASHBOARD_PATHS} from "../../_routes";
-// import InfoCard from "../../core/components/InfoCard/InfoCard";
+import InfoCard from "../../core/components/InfoCard/InfoCard";
 import {APPLICATIONS_LIMIT, STYLING, TABLE_COLUMNS} from "../../_constants";
 import NetworkService from "../../core/services/PocketNetworkService";
 import Loader from "../../core/components/Loader";
@@ -15,14 +15,14 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import AppTable from "../../core/components/AppTable";
 
 // TODO: Integrate this data with backend.
-// const CARDS = [
-//   {title: "US $0.00", subtitle: "POKT Price"},
-//   {title: "33,456", subtitle: "Total Staked Tokens"},
-//   {title: "23,345", subtitle: "Total of nodes"},
-//   {title: "21,479", subtitle: "Total Staked nodes"},
-//   {title: "38,353", subtitle: "Total of apps"},
-//   {title: "37,235", subtitle: "Total Staked apps"},
-// ];
+const CARDS = [
+  {title: "US $0.00", subtitle: "POKT Price"},
+  {title: "33,456", subtitle: "Total Staked Tokens"},
+  {title: "23,345", subtitle: "Total of nodes"},
+  {title: "21,479", subtitle: "Total Staked nodes"},
+  {title: "38,353", subtitle: "Total of apps"},
+  {title: "37,235", subtitle: "Total Staked apps"},
+];
 
 class Dashboard extends Component {
   constructor(props, context) {
@@ -168,15 +168,15 @@ class Dashboard extends Component {
             </Dropdown>
           </Col>
         </Row>
-        {/* <Row className="stats mb-4" noGutters>
+        <Row className="stats mb-4" noGutters>
           {CARDS.map((card, idx) => (
             <Col key={idx} className="stat-column" md={2}>
               <InfoCard title={card.title} subtitle={card.subtitle} />
             </Col>
           ))}
-        </Row> */}
+        </Row>
         <div className="network-status-tables">
-          {/* <Row className="network-status-tables-row">
+          <Row className="network-status-tables-row">
             <Col sm="6" className="network-status-table">
               <Segment scroll={false} label="Registered Nodes">
                 <AppTable
@@ -205,7 +205,7 @@ class Dashboard extends Component {
                 />
               </Segment>
             </Col>
-          </Row> */}
+          </Row>
           <Row>
             <Col
               sm="12"
@@ -224,7 +224,7 @@ class Dashboard extends Component {
                 />
               </Segment>
             </Col>
-            {/* <Col
+            <Col
               sm="12"
               className={`network-status-table ${
                 chains.length === 0 ? "segment-table-empty" : ""
@@ -240,7 +240,7 @@ class Dashboard extends Component {
                   bordered={false}
                 />
               </Segment>
-            </Col> */}
+            </Col>
           </Row>
         </div>
       </div>

--- a/frontend/src/views/Dashboard/Dashboard.js
+++ b/frontend/src/views/Dashboard/Dashboard.js
@@ -3,7 +3,7 @@ import UserService from "../../core/services/PocketUserService";
 import {Alert, Col, Dropdown, Row} from "react-bootstrap";
 import "./Dashboard.scss";
 import {_getDashboardPath, DASHBOARD_PATHS} from "../../_routes";
-import InfoCard from "../../core/components/InfoCard/InfoCard";
+// import InfoCard from "../../core/components/InfoCard/InfoCard";
 import {APPLICATIONS_LIMIT, STYLING, TABLE_COLUMNS} from "../../_constants";
 import NetworkService from "../../core/services/PocketNetworkService";
 import Loader from "../../core/components/Loader";
@@ -15,14 +15,14 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import AppTable from "../../core/components/AppTable";
 
 // TODO: Integrate this data with backend.
-const CARDS = [
-  {title: "US $0.60", subtitle: "POKT Price"},
-  {title: "33,456", subtitle: "Total Staked Tokens"},
-  {title: "23,345", subtitle: "Total of nodes"},
-  {title: "21,479", subtitle: "Total Staked nodes"},
-  {title: "38,353", subtitle: "Total of apps"},
-  {title: "37,235", subtitle: "Total Staked apps"},
-];
+// const CARDS = [
+//   {title: "US $0.00", subtitle: "POKT Price"},
+//   {title: "33,456", subtitle: "Total Staked Tokens"},
+//   {title: "23,345", subtitle: "Total of nodes"},
+//   {title: "21,479", subtitle: "Total Staked nodes"},
+//   {title: "38,353", subtitle: "Total of apps"},
+//   {title: "37,235", subtitle: "Total Staked apps"},
+// ];
 
 class Dashboard extends Component {
   constructor(props, context) {
@@ -168,15 +168,15 @@ class Dashboard extends Component {
             </Dropdown>
           </Col>
         </Row>
-        <Row className="stats mb-4" noGutters>
+        {/* <Row className="stats mb-4" noGutters>
           {CARDS.map((card, idx) => (
             <Col key={idx} className="stat-column" md={2}>
               <InfoCard title={card.title} subtitle={card.subtitle} />
             </Col>
           ))}
-        </Row>
+        </Row> */}
         <div className="network-status-tables">
-          <Row className="network-status-tables-row">
+          {/* <Row className="network-status-tables-row">
             <Col sm="6" className="network-status-table">
               <Segment scroll={false} label="Registered Nodes">
                 <AppTable
@@ -205,7 +205,7 @@ class Dashboard extends Component {
                 />
               </Segment>
             </Col>
-          </Row>
+          </Row> */}
           <Row>
             <Col
               sm="12"
@@ -224,7 +224,7 @@ class Dashboard extends Component {
                 />
               </Segment>
             </Col>
-            <Col
+            {/* <Col
               sm="12"
               className={`network-status-table ${
                 chains.length === 0 ? "segment-table-empty" : ""
@@ -240,7 +240,7 @@ class Dashboard extends Component {
                   bordered={false}
                 />
               </Segment>
-            </Col>
+            </Col> */}
           </Row>
         </div>
       </div>

--- a/frontend/src/views/Nodes/NodePassphrase/Nodepassphrase.js
+++ b/frontend/src/views/Nodes/NodePassphrase/Nodepassphrase.js
@@ -20,7 +20,7 @@ class NodePassphrase extends Passphrase {
     );
 
     if (success) {
-      const {privateNodeData} = data;
+      const {privateNodeData, ppkData} = data;
       const {address, privateKey} = privateNodeData;
 
       NodeService.removeNodeInfoFromCache();
@@ -34,6 +34,7 @@ class NodePassphrase extends Passphrase {
         created: true,
         address,
         privateKey,
+        ppkData
       });
     } else {
       this.setState({error: {show: true, message: data.message}});

--- a/frontend/src/views/Profile/PaymentHistory/PaymentHistory.js
+++ b/frontend/src/views/Profile/PaymentHistory/PaymentHistory.js
@@ -44,7 +44,7 @@ class PaymentHistory extends Component {
 
   handleExport(data) {
     // TODO: Add export to downloadable file functionality
-    console.log(data);
+    // console.log(data);
   }
 
   renderExport(cell, row) {


### PR DESCRIPTION
Contains the following changes:

1. Changes private key file import and export to use the PPK format: https://github.com/pokt-network/pocket-core/blob/staging/doc/portable-private-key-spec.md
2. Updated PocketJS to `0.5.0-rc`
3. Switched from HTTPRpcProvider to PocketRpcProvider.
4. Adds the following environment variables:

- POCKET_NETWORK_CHAIN_ID (the current Pocket Network the dashboard is connecting to i.e “testnet”)
- POCKET_NETWORK_DISPATCHERS (A comma separated list of dispatchers to use when connecting to the Pocket Network)
- POCKET_NETWORK_CHAIN_HASH (The Pocket Network chain hash to use to connect to Pocket i.e. “0002”, more info see here: https://docs.pokt.network/docs/supported-networks)
- POCKET_NETWORK_AAT_CLIENT_PRIV_KEY (The Private Key of the Dashboard Client application, it can be any valid ed25519 private key)
- POCKET_NETWORK_AAT_APP_PRIV_KEY (The private key of an application staked in the Pocket Network that will be used to submit relays to the Pocket blockchain)
- POCKET_NETWORK_AAT_CLIENT_PASSPHRASE (A passphrase that will be used to secure the POCKET_NETWORK_AAT_CLIENT_PRIV_KEY)