### PR TITLE
Staking: Re-enable staking for free tier apps

### DIFF
--- a/backend/src/CronJob.js
+++ b/backend/src/CronJob.js
@@ -81,9 +81,10 @@ export function startCronJobs() {
                   case POST_ACTION_TYPE.stakeApplication: {
                     const appStakeTransaction =
                       postAction.data.appStakeTransaction;
+
                     const stakeAppPostActionHash = await POCKET_SERVICE.submitRawTransaction(
                       appStakeTransaction.address,
-                      appStakeTransaction.raw_hex_bytes
+                      appStakeTransaction.txHex
                     );
 
                     await TRANSACTION_SERVICE.addAppStakeTransaction(
@@ -165,7 +166,6 @@ export function startCronJobs() {
             networkData,
             error,
           } = await APPLICATION_SERVICE.getApplication(address);
-
           const hasError = error ? true : false;
           const errorType = hasError === true ? error : "";
 

--- a/backend/src/apis/ApplicationApi.js
+++ b/backend/src/apis/ApplicationApi.js
@@ -285,22 +285,31 @@ router.post(
 /**
  * Stake a free tier application.
  */
-// router.post("/freetier/stake", apiAsyncWrapper(async (req, res) => {
-// [>* @type {{stakeInformation: {client_address: string, chains: string[], stake_amount: string}, applicationLink: string}} <]
-// const data = req.body;
+router.post(
+  "/freetier/stake",
+  apiAsyncWrapper(async (req, res) => {
+    // [>* @type {{stakeInformation: {client_address: string, chains: string[], stake_amount: string}, applicationLink: string}} <]
+    const data = req.body;
 
-// const stakeInformation = data.stakeInformation;
-// const application = await applicationService.getApplication(stakeInformation.client_address);
+    const stakeInformation = data.stakeInformation;
+    const application = await applicationService.getApplication(
+      stakeInformation.client_address
+    );
 
-// const applicationEmailData = {
-// name: application.pocketApplication.name,
-// link: data.applicationLink
-// };
+    const applicationEmailData = {
+      name: application.pocketApplication.name,
+      link: data.applicationLink,
+    };
 
-// const aat = await applicationService.stakeFreeTierApplication(application, stakeInformation, applicationEmailData);
+    const aat = await applicationService.stakeFreeTierApplication(
+      application,
+      stakeInformation,
+      applicationEmailData
+    );
 
-// res.json(aat);
-// }));
+    res.json(aat);
+  })
+);
 
 /**
  * Unstake a free tier application.

--- a/backend/src/services/ApplicationService.js
+++ b/backend/src/services/ApplicationService.js
@@ -624,7 +624,7 @@ export default class ApplicationService extends BasePocketService {
    *
    * @async
    * @param {ExtendedPocketApplication} application Application to stake.
-   * @param {{app_address: string, chains: string[], stake_amount: string}} stakeInformation Information for the stake action.
+   * @param {{client_address: string, chains: string[], stake_amount: string}} stakeInformation Information for the stake action.
    * @param {{name: string, link: string}} emailData Email data.
    * @returns {Promise<PocketAAT | boolean>} If application was created or not.
    */
@@ -687,7 +687,7 @@ export default class ApplicationService extends BasePocketService {
         appStakeTransaction,
         contactEmail,
         emailData,
-        address: stakeInformation.app_address,
+        address: stakeInformation.client_address,
         paymentEmailData: {
           amountPaid: 0,
           poktStaked: upoktToStake / Math.pow(10, POKT_DENOMINATIONS.upokt),

--- a/backend/webpack.config.js
+++ b/backend/webpack.config.js
@@ -12,14 +12,14 @@ module.exports = {
     globalObject: "this",
     path: path.join(__dirname, "dist"),
     publicPath: "/",
-    filename: "[name].js"
+    filename: "[name].js",
   },
   target: "web",
   devtool: "inline-source-map",
   node: {
     // Need this when working with express, otherwise the build fails
-    __dirname: false,   // if you don't put this is, __dirname
-    __filename: false,  // and __filename return blank or /
+    __dirname: false, // if you don't put this is, __dirname
+    __filename: false, // and __filename return blank or /
   },
   externals: [nodeExternals()], // Need this to avoid error when working with Express
   module: {
@@ -32,21 +32,18 @@ module.exports = {
         options: {
           emitWarning: true,
           failOnError: false,
-          failOnWarning: false
-        }
+          failOnWarning: false,
+        },
       },
       {
         // Transpiles ES6-8 into ES5
         test: /\.js$/,
         exclude: /node_modules/,
         use: {
-          loader: "babel-loader"
-        }
+          loader: "babel-loader",
+        },
       },
-    ]
+    ],
   },
-  plugins: [
-    new webpack.NoEmitOnErrorsPlugin(),
-    new Dotenv()
-  ]
+  plugins: [new webpack.NoEmitOnErrorsPlugin(), new Dotenv()],
 };

--- a/frontend/src/core/services/PocketApplicationService.js
+++ b/frontend/src/core/services/PocketApplicationService.js
@@ -412,14 +412,12 @@ export class PocketApplicationService extends PocketBaseService {
         applicationLink,
       })
       .then((response) => {
-        console.log("FRONTEND RESPONSE: ", response);
         return {
           success: true,
           data: response.data,
         };
       })
       .catch((err) => {
-        console.log("ERROR on PocketApplicationService: ", err);
         return {
           success: false,
           data: err.response.data.message,

--- a/frontend/src/core/services/PocketApplicationService.js
+++ b/frontend/src/core/services/PocketApplicationService.js
@@ -412,12 +412,14 @@ export class PocketApplicationService extends PocketBaseService {
         applicationLink,
       })
       .then((response) => {
+        console.log("FRONTEND RESPONSE: ", response);
         return {
           success: true,
           data: response.data,
         };
       })
       .catch((err) => {
+        console.log("ERROR on PocketApplicationService: ", err);
         return {
           success: false,
           data: err.response.data.message,

--- a/frontend/src/views/Apps/ChainList/ApplicationChainList.js
+++ b/frontend/src/views/Apps/ChainList/ApplicationChainList.js
@@ -51,10 +51,7 @@ class ApplicationChainList extends Chains {
 
     this.setState({ creatingFreeTier: true });
 
-    const {
-      success,
-      name: errorType,
-    } = await PocketApplicationService.stakeFreeTierApplication(
+    const { success } = await PocketApplicationService.stakeFreeTierApplication(
       stakeInformation,
       applicationLink
     );

--- a/frontend/src/views/Apps/ChainList/ApplicationChainList.js
+++ b/frontend/src/views/Apps/ChainList/ApplicationChainList.js
@@ -30,15 +30,12 @@ class ApplicationChainList extends Chains {
       passphrase,
     } = PocketApplicationService.getApplicationInfo();
 
-    console.log("app info:", id, address, chains, passphrase);
-
     const unlockedAccount = await PocketClientService.getUnlockedAccount(
       address,
       passphrase
     );
     const clientAddressHex = unlockedAccount.addressHex;
 
-    console.log("acc info:", unlockedAccount, clientAddressHex);
     const url = _getDashboardPath(DASHBOARD_PATHS.appDetail);
 
     const detail = url.replace(":id", id);
@@ -51,8 +48,6 @@ class ApplicationChainList extends Chains {
       chains: chains,
       stake_amount: stakeAmount,
     };
-
-    console.log("STAKE INFORMATION", stakeInformation);
 
     this.setState({ creatingFreeTier: true });
 
@@ -70,7 +65,7 @@ class ApplicationChainList extends Chains {
         _getDashboardPath(`${DASHBOARD_PATHS.appDetail.replace(":id", id)}`)
       );
     } else {
-      console.log("RIP, see logs above");
+      // TODO: handle error on UI
     }
   }
 


### PR DESCRIPTION
Re-enables staking logic for free tier apps, so that users can keep registering endpoints and using them (but not pay for new ones). Closes #581.

Can be reviewed commit by commit. Here's the task list:
- [x] Re-enable endpoints for staking free tier apps
- [x] Move staking logic to the `ApplicationChainList` component
To-do later (will convert to relevant issues):
- [ ] Modernize the `ApplicationChainList` component to use hooks
- [ ] Handle the success case and error case on the UI
- [ ] Nail and document the reason why the Cronjob cannot send the staking email (known issue, will write about it later)
- [x] Squash some useless commits