### PR TITLE
Frontend: Enable absolute imports

### DIFF
--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,6 @@
+ {
+   "compilerOptions": {
+     "baseUrl": "src"
+   },
+   "include": "src"
+ }


### PR DESCRIPTION
Creates a `jsconfig.json` file for being able to have absolute imports. Trying this out for the first time to avoid having a plethora of relative imports. Will come especially useful as the in-house design system evolves. :)